### PR TITLE
update vscode extensions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
   "portsAttributes": {
     "3000": {
       "label": "Application",
-      "onAutoForward": "openPreview"
+      // "onAutoForward": "openPreview"
     }
   },
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,9 @@
     "vscode": {
       "extensions": ["vortizhe.simple-ruby-erb",
                      "mbessey.vscode-rufo",
-                     "aliariff.vscode-erb-beautify"]
+                     "aliariff.vscode-erb-beautify",
+                     "eamodio.gitlens",
+                     "mhutchie.git-graph"]
     }
   }
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,8 +13,7 @@
 
   "portsAttributes": {
     "3000": {
-      "label": "Application",
-      // "onAutoForward": "openPreview"
+      "label": "Application"
     }
   },
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -16,4 +16,7 @@ ports:
 vscode:
   extensions:
     - vortizhe.simple-ruby-erb
+    - mbessey.vscode-rufo
     - aliariff.vscode-erb-beautify
+    - eamodio.gitlens
+    - mhutchie.git-graph

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,6 +34,7 @@
   "vscode-erb-beautify.keepBlankLines": 1,
   "ruby.intellisense": false,
   "gitpod.openInStable.neverPrompt": true,
+  "gitlens.showWelcomeOnInstall": false,
   "redhat.telemetry.enabled": false,
   "emmet.includeLanguages": {
     "erb": "html"


### PR DESCRIPTION
Per this discussion: https://github.com/jelaniwoods-appdev/appdev-rails-7/issues/13

Also, changed the .vscode settings to prevent a welcome screen from popping up for GitLens on first opening (and installation) in a Codespace.

Also, no auto forwarding of 3000 port in Codespaces (often doesn't open correctly, plan is have students use the toast message or the "Ports" tab of the terminal)