### PR TITLE
Change to Dockerfile for better_errors in Sinatra on cloud IDEs

### DIFF
--- a/appdev.Dockerfile
+++ b/appdev.Dockerfile
@@ -201,3 +201,6 @@ __git_complete g __git_main" >> ~/.bash_aliases
 # Alias bundle exec to be
 RUN echo "alias be='bundle exec'" >> ~/.bash_aliases
 RUN sudo cp -r /home/student /home/gitpod && sudo chmod 777 /home/gitpod
+
+# Add trusted IP for better_errors use with Sinatra on cloud IDEs
+RUN echo "export TRUSTED_IP='0.0.0.0/0.0.0.0'" >> ~/.bashrc


### PR DESCRIPTION
Spent too long debugging this all morning.

# Problem

When using the `better_errors` gem in a Sinatra app in a local dev environment, everything worked fine. But when I tried the code on Codespaces or Gitpod, I was consistently getting the old, hard to read error messages in the browser. 

## Solution

I finally found this [old SO post](https://stackoverflow.com/questions/27117443/why-doesnt-better-errors-work-on-cloud-9-ide) and the suggested fix worked. The steps were:

1. `echo "export TRUSTED_IP='0.0.0.0/0.0.0.0'" >> ~/.bashrc`

2. `source ~/.bashrc`

3. In the Sinatra app configuration:

```
use BetterErrors::Middleware
BetterErrors.application_root = __dir__
BetterErrors::Middleware.allow_ip! ENV['TRUSTED_IP'] if ENV['TRUSTED_IP']
```

## Proposed change

Can we update the Dockerfile to include that `TRUSTED_IP` export to the bash profile? This will require rebuilding the image and replacing it in the `devcontainer.json` and `.gitpod.yml` file as well after rebuild (unless we're just using the "latest" tag for the current image).

## Discussion point

This change is only to make Sinatra work (specifically with `better_errors`). Of course, this is a Rails 7 template. In the interest of easier maintaining, I'm still in favor of using this template / image for all AppDev projects. Yes, it is overkill for Sinatra and requires this one hack (I didn't find any other issues so far...), but maintaining a single image (for now) seems easiest.

Also, we might want to add `sinatra` and `sinatra-contrib` gems to the Gemfile in a separate PR? 