### PR TITLE
Remove GitGraph extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,8 +26,7 @@
       "extensions": ["vortizhe.simple-ruby-erb",
                      "mbessey.vscode-rufo",
                      "aliariff.vscode-erb-beautify",
-                     "eamodio.gitlens",
-                     "mhutchie.git-graph"]
+                     "eamodio.gitlens"]
     }
   }
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -19,4 +19,3 @@ vscode:
     - mbessey.vscode-rufo
     - aliariff.vscode-erb-beautify
     - eamodio.gitlens
-    - mhutchie.git-graph


### PR DESCRIPTION
GitLens now has a very nice graph built in (~November 2022 release -- works very well, no complaints from the community of users). No need for two graphs so we can remove this extension.