### PR TITLE
Disable default GitLens blame

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,6 +35,7 @@
   "ruby.intellisense": false,
   "gitpod.openInStable.neverPrompt": true,
   "gitlens.showWelcomeOnInstall": false,
+  "gitlens.currentLine.enabled": false,
   "redhat.telemetry.enabled": false,
   "emmet.includeLanguages": {
     "erb": "html"


### PR DESCRIPTION
We think the "blame" shown on each line in VSCode with GitLens is just going to be distracting for students. Turning it off in the settings.