### PR TITLE
Add bin/rake to PATH for non-Rails projects

### DIFF
--- a/appdev.Dockerfile
+++ b/appdev.Dockerfile
@@ -205,3 +205,6 @@ __git_complete g __git_main" >> ~/.bash_aliases
 # Alias bundle exec to be
 RUN echo "alias be='bundle exec'" >> ~/.bash_aliases
 # RUN sudo cp -r /home/student /home/gitpod && sudo chmod 777 /home/gitpod
+
+# Add bin/rake to path for non-Rails projects
+RUN echo 'export PATH="$PWD/bin:$PATH"' >> ~/.bashrc


### PR DESCRIPTION
A bunch of projects (based on Sinatra) are still using the Rails 7 image. But in those projects `bin/rake` is not on the `PATH`. I've added it to the Docker image here, by prepending. Appending (i.e. `PATH="$PATH:$PWD/bin"`) did not work.

@jelaniwoods I think you will need to rebuild the Docker image at `jelaniwoods/appdev2023-rails-template`