### PR TITLE
Remove DATABASE_URL environment variable

### DIFF
--- a/appdev.Dockerfile
+++ b/appdev.Dockerfile
@@ -84,12 +84,9 @@ COPY --chown=student:student Gemfile.lock /rails-template/Gemfile.lock
 RUN /bin/bash -l -c "bundle install"
 
 # Install Google Chrome
-RUN sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" | \
-    tee -a /etc/apt/sources.list.d/google.list' && \
-    wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | \
-    sudo apt-key add - && \
-    sudo apt-get update && \
-    sudo apt-get install -y google-chrome-stable libxss1
+RUN sudo apt-get update && sudo apt-get install -y libxss1
+RUN wget https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_114.0.5735.198-1_amd64.deb && \
+    sudo apt-get install -y ./google-chrome-stable_114.0.5735.198-1_amd64.deb
 
 # Install Chromedriver (compatable with Google Chrome version)
 #   See https://gerg.dev/2021/06/making-chromedriver-and-chrome-versions-match-in-a-docker-image/
@@ -122,7 +119,7 @@ RUN mkdir -p $PGDATA ~/.pg_ctl/bin ~/.pg_ctl/sockets \
  && sudo setfacl -dR -m g:staff:rwx $PGDATA \
  && sudo chmod 777 /var/run/postgresql
 ENV PATH="$PATH:$HOME/.pg_ctl/bin"
-ENV DATABASE_URL="postgresql://student@localhost"
+# ENV DATABASE_URL="postgresql://student@localhost"
 ENV PGHOSTADDR="127.0.0.1"
 ENV PGDATABASE="postgres"
 


### PR DESCRIPTION
Fixes issue where test db wouldn't create and issue where sqlite configuration wouldn't work

Also adds explicit google chrome version, since previous docker instructions failed due to a breaking change in stable google chrome releases.