### PR TITLE
Remove traces of 'vanilla'

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>VanillaRails7</title>
+    <title>Rails Template</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,7 +6,7 @@ require "rails/all"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
-module VanillaRails7
+module RailsTemplate
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -8,4 +8,4 @@ test:
 production:
   adapter: redis
   url: <%= ENV.fetch("REDIS_URL") { "redis://localhost:6379/1" } %>
-  channel_prefix: vanilla_rails_7_production
+  channel_prefix: rails_template_production

--- a/config/database.yml
+++ b/config/database.yml
@@ -23,13 +23,13 @@ default: &default
 
 development:
   <<: *default
-  database: vanilla_rails_7_development
+  database: rails_template_development
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
   # When left blank, postgres will use the default role. This is
   # the same name as the operating system user running Rails.
-  #username: vanilla_rails_7
+  #username: rails_template
 
   # The password associated with the postgres role (username).
   #password:
@@ -57,7 +57,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: vanilla_rails_7_test
+  database: rails_template_test
 
 # As with config/credentials.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is
@@ -81,6 +81,6 @@ test:
 #
 production:
   <<: *default
-  database: vanilla_rails_7_production
-  username: vanilla_rails_7
-  password: <%= ENV["VANILLA_RAILS_7_DATABASE_PASSWORD"] %>
+  database: rails_template_production
+  username: rails_template
+  password: <%= ENV["RAILS_TEMPLATE_DATABASE_PASSWORD"] %>

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -60,7 +60,7 @@ Rails.application.configure do
 
   # Use a real queuing backend for Active Job (and separate queues per environment).
   # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "vanilla_rails_7_production"
+  # config.active_job.queue_name_prefix = "rails_template_production"
 
   config.action_mailer.perform_caching = false
 


### PR DESCRIPTION
Removing traces of the word "vanilla" in the codebase. Also removing "7", since this will be the new standard for a while.