### PR TITLE
Remove webdriver gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,7 +68,6 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
-  gem "webdrivers"
 end
 
 # AppDev Gems

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -382,10 +382,6 @@ GEM
       git
       sinatra
       tzinfo-data
-    webdrivers (5.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (~> 4.0)
     webmock (3.18.1)
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
@@ -440,7 +436,6 @@ DEPENDENCIES
   tzinfo-data
   web-console
   web_git
-  webdrivers
   webmock
 
 RUBY VERSION

--- a/spec/support/headless_chrome.rb
+++ b/spec/support/headless_chrome.rb
@@ -1,5 +1,3 @@
-require "webdrivers/chromedriver"
-
 Capybara.register_driver :headless_chrome do |app|
   options = Selenium::WebDriver::Chrome::Options.new
   options.add_argument("--headless")

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,5 +1,6 @@
 require "test_helper"
+require_relative "../spec/support/headless_chrome"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
+  driven_by :selenium, using: :headless_chrome
 end

--- a/test/system/example_test.rb
+++ b/test/system/example_test.rb
@@ -1,0 +1,8 @@
+require "application_system_test_case"
+
+class MoviesTest < ApplicationSystemTestCase
+  test "visiting the index" do
+    visit "/movies"
+    assert_selector "h1", text: "List of all movies"
+  end
+end


### PR DESCRIPTION
Similar to this issue: https://github.com/firstdraft/learn/pull/216

I ran into an issue when writing a few Minitest specs for Phase 2 projects in the `test` folder. With this change, both

```
bundle exec rspec
```

and 

```
rails test
```

Work without issue.