### PR TITLE
Update Gitpod before script

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,10 +1,7 @@
 image: jelaniwoods/appdev2023-rails-template
 
 tasks:
-  - env:
-      DATABASE_URL: "postgresql://gitpod@localhost"
-    before: |
-      sudo echo 'export DATABASE_URL="postgresql://gitpod@localhost"' | sudo tee -a ~/.bashrc
+  - before: |
       sudo cp -r /home/student /home/gitpod
       (cd /home/gitpod/student; sudo find . -maxdepth 1 -exec mv {} .. \;)
       source ~/.bashrc

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,6 +4,7 @@ tasks:
   - env:
       DATABASE_URL: "postgresql://gitpod@localhost"
     before: |
+      sudo echo 'export DATABASE_URL="postgresql://gitpod@localhost"' | sudo tee -a ~/.bashrc
       sudo cp -r /home/student /home/gitpod
       (cd /home/gitpod/student; sudo find . -maxdepth 1 -exec mv {} .. \;)
       source ~/.bashrc

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,16 +4,10 @@ tasks:
   - env:
       DATABASE_URL: "postgresql://gitpod@localhost"
     before: |
-      if [ -d "/home/gitpod" ]; then
-        sudo cp -r /home/student /home/gitpod
-        (cd /home/gitpod/student; sudo find . -maxdepth 1 -exec mv {} .. \;)
-        source ~/.bashrc
-        sudo chmod 777 /home/gitpod && sudo chown -R gitpod /home/gitpod
-        echo "/home/gitpod exists"
-      else
-        sudo cp -r /home/student /home/gitpod && sudo chmod 777 /home/gitpod && chown -R gitpod /home/gitpod
-        echo "/home/gitpod does not exist"
-      fi
+      sudo cp -r /home/student /home/gitpod
+      (cd /home/gitpod/student; sudo find . -maxdepth 1 -exec mv {} .. \;)
+      source ~/.bashrc
+      sudo chmod 777 /home/gitpod && sudo chown -R gitpod /home/gitpod
       export GEM_HOME=/workspace/.rvm
       export GEM_PATH=$GEM_HOME:$GEM_PATH
       export PATH=/workspace/.rvm/bin:$PATH

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,8 +4,16 @@ tasks:
   - env:
       DATABASE_URL: "postgresql://gitpod@localhost"
     before: |
-      sudo echo 'export DATABASE_URL="postgresql://gitpod@localhost"' | sudo tee -a ~/.bashrc
-      sudo cp -r /home/student /home/gitpod && sudo chmod 777 /home/gitpod && chown -R gitpod /home/gitpod
+      if [ -d "/home/gitpod" ]; then
+        sudo cp -r /home/student /home/gitpod
+        (cd /home/gitpod/student; sudo find . -maxdepth 1 -exec mv {} .. \;)
+        source ~/.bashrc
+        sudo chmod 777 /home/gitpod && sudo chown -R gitpod /home/gitpod
+        echo "/home/gitpod exists"
+      else
+        sudo cp -r /home/student /home/gitpod && sudo chmod 777 /home/gitpod && chown -R gitpod /home/gitpod
+        echo "/home/gitpod does not exist"
+      fi
       export GEM_HOME=/workspace/.rvm
       export GEM_PATH=$GEM_HOME:$GEM_PATH
       export PATH=/workspace/.rvm/bin:$PATH


### PR DESCRIPTION
## Problem

Projects and suddenly having issues setting up in Gitpod

![image](https://github.com/appdev-projects/rails-7-template/assets/17581658/f70770a2-1017-4695-8ba2-ce4928ff8d78)

The image is being pulled correctly (since there are files and folders present that only exist in our image) but errors occur during the "before" task.

---

The cause of this new behavior appears to be because the container now has creates a `/home/gitpod/` directory _before_ the `before` task runs, which wasn't the case before. The `cp -R`  command behaves differently depending on if the destination folder exists or not. When the folder does exist the source directory is added as a sub-folder instead of adding the contents directly in the destination folder. The previous script started to create a sub-folder which was breaking the `chown` command.

## Solution

The `before` task has been updated to:
- copy contents of student to gitpod (creating sub-folder)
- move the contents of the student sub-folder to it's parent gitpod folder.
- `source ~/.bashrc` to ensure Bash configuration is loaded before `bin/setup`

