### PR TITLE
Deactivate Turbo initially

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,3 +1,5 @@
 // Configure your import map in config/importmap.rb. Read more: https://github.com/rails/importmap-rails
-import "@hotwired/turbo-rails"
+import { Turbo } from "@hotwired/turbo-rails"
 import "controllers"
+
+Turbo.session.drive = false


### PR DESCRIPTION
## Problem

With Turbo enabled by default, form submissions and link navigations that would normally cause a "No Route matches" error, instead simply appear to refresh the page. While this is the expected behavior for Turbo (only updating the page when successful responses are sent) this is an unexpected behavior for beginners.

![appdev-template-turbo-no-route-issue](https://github.com/appdev-projects/rails-7-template/assets/17581658/2bf28fec-261c-43d0-99fe-18d6a1c1e4ee)


## Solution

This PR proposes that we deactivate Turbo initially, so that students in AppDev I/Phase 1 content are not confused by this behavior. This also allows for more advanced students (AppDev II/Phase II) to re-activate Turbo if/when they need it.

https://turbo.hotwired.dev/handbook/drive#disabling-turbo-drive-on-specific-links-or-forms

### Concerns

This change to default behavior could lead to confusion for current advanced students using this outside of UChicago. We need to consider who this affects and what kinds of consequences this change will have before merging.