### PR TITLE
Reduce docker image size and move to firstdraft dockerhub

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
   "name": "Container",
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "jelaniwoods/appdev2023-rails-template",
+  "image": "firstdraft/appdev-rails-template",
 
   // Features to add to the dev container. More info: https://containers.dev/features.
   // "features": {},

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: jelaniwoods/appdev2023-rails-template
+image: firstdraft/appdev-rails-template
 
 tasks:
   - before: |

--- a/appdev.Dockerfile
+++ b/appdev.Dockerfile
@@ -204,5 +204,8 @@ __git_complete g __git_main" >> ~/.bash_aliases
 RUN echo "alias be='bundle exec'" >> ~/.bash_aliases
 # RUN sudo cp -r /home/student /home/gitpod && sudo chmod 777 /home/gitpod
 
+# Alias rake grade to grade
+RUN echo "alias grade='rake grade'" >> ~/.bash_aliases
+
 # Add bin/rake to path for non-Rails projects
 RUN echo 'export PATH="$PWD/bin:$PATH"' >> ~/.bashrc

--- a/appdev.Dockerfile
+++ b/appdev.Dockerfile
@@ -197,6 +197,7 @@ RUN echo "alias be='bundle exec'" >> ~/.bash_aliases
 
 # Alias rake grade to grade
 RUN echo "alias grade='rake grade'" >> ~/.bash_aliases
+RUN echo "alias grade:reset_token='rake grade:reset_token'" >> ~/.bash_aliases
 
 # Add bin/rake to path for non-Rails projects
 RUN echo 'export PATH="$PWD/bin:$PATH"' >> ~/.bashrc

--- a/appdev.Dockerfile
+++ b/appdev.Dockerfile
@@ -1,4 +1,4 @@
-FROM buildpack-deps:focal
+FROM ubuntu:focal
 
 ### base ###
 RUN yes | unminimize \
@@ -8,16 +8,13 @@ RUN yes | unminimize \
         unzip \
         bash-completion \
         build-essential \
-        htop \
         jq \
         less \
         locales \
         man-db \
-        nano \
         software-properties-common \
         sudo \
         time \
-        vim \
         multitail \
         lsof \
     && locale-gen en_US.UTF-8 \

--- a/appdev.Dockerfile
+++ b/appdev.Dockerfile
@@ -155,9 +155,6 @@ RUN sudo apt-get update \
   redis-server=5:5.0.7-2ubuntu0.1 \
  && sudo rm -rf /var/lib/apt/lists/*
 
-# Install heroku-cli
-RUN /bin/bash -l -c "curl https://cli-assets.heroku.com/install.sh | sh"
-
 # Install flyyctl
 RUN /bin/bash -l -c "curl -L https://fly.io/install.sh | sh"
 RUN echo "export PATH=\"/home/student/.fly/bin:\$PATH\"" >> ~/.bashrc

--- a/appdev.Dockerfile
+++ b/appdev.Dockerfile
@@ -1,22 +1,22 @@
 FROM ubuntu:focal
 
 ### base ###
+ENV DEBIAN_FRONTEND=noninteractive
 RUN yes | unminimize \
     && apt-get install -yq \
+        curl \
+        wget \
         acl \
         zip \
         unzip \
         bash-completion \
         build-essential \
         jq \
-        less \
         locales \
         man-db \
         software-properties-common \
+        libpq-dev \
         sudo \
-        time \
-        multitail \
-        lsof \
     && locale-gen en_US.UTF-8 \
     && mkdir /var/lib/apt/dazzle-marks \
     && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/*
@@ -81,7 +81,7 @@ COPY --chown=student:student Gemfile.lock /rails-template/Gemfile.lock
 RUN /bin/bash -l -c "bundle install"
 
 # Install Google Chrome
-RUN sudo apt-get update && sudo apt-get install -y libxss1
+RUN sudo apt-get update && sudo apt-get install -y libxss1 && sudo rm -rf /var/lib/atp/lists/*
 RUN wget https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_114.0.5735.198-1_amd64.deb && \
     sudo apt-get install -y ./google-chrome-stable_114.0.5735.198-1_amd64.deb
 
@@ -144,7 +144,8 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
     && sudo apt-get install -y yarn \
     && sudo npm install -g n \
     && sudo n 18 \
-    && hash -r
+    && hash -r \
+    && sudo rm -rf /var/lib/apt/lists/*
 
 # Install Redis.
 RUN sudo apt-get update \

--- a/appdev.Dockerfile
+++ b/appdev.Dockerfile
@@ -193,9 +193,5 @@ __git_complete g __git_main" >> ~/.bash_aliases
 RUN echo "alias be='bundle exec'" >> ~/.bash_aliases
 # RUN sudo cp -r /home/student /home/gitpod && sudo chmod 777 /home/gitpod
 
-# Alias rake grade to grade
-RUN echo "alias grade='rake grade'" >> ~/.bash_aliases
-RUN echo "alias grade:reset_token='rake grade:reset_token'" >> ~/.bash_aliases
-
 # Add bin/rake to path for non-Rails projects
 RUN echo 'export PATH="$PWD/bin:$PATH"' >> ~/.bashrc

--- a/appdev.Dockerfile
+++ b/appdev.Dockerfile
@@ -136,12 +136,6 @@ RUN /bin/bash -l -c "sudo apt update && sudo apt install -y graphviz=2.42.2-3bui
 # Install fuser (bin/server) and expect (web_git)
 RUN sudo apt install -y libpq-dev psmisc lsof expect
 
-# Install parity
-RUN wget -qO - https://apt.thoughtbot.com/thoughtbot.gpg.key | sudo apt-key add - \
-    && echo "deb http://apt.thoughtbot.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/thoughtbot.list \
-    && sudo apt-get update \
-    && sudo apt-get -y install parity=3.5.0-2
-
 # Install Node and npm
 RUN curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash - \
     && sudo apt-get install -y nodejs


### PR DESCRIPTION
**NOTE about branch name:** I can't change the branch name here without closing this PR and losing my line comments. So I'm leaving it as is, even though the branch name is a poor description of what was done here.

Resolves https://github.com/appdev-projects/rails-7-template/issues/30

Resolves https://github.com/appdev-lessons/codespaces-setup/issues/3

Now that we have a `firstdraft` Dockerhub account, I ran:

```
docker build --platform linux/amd64 -t firstdraft/appdev-rails-template -f appdev.Dockerfile .

docker push firstdraft/appdev-rails-template
```

This will require updates to all of the `devcontainer.json` and `.gitpod.yml` files in all `appdev-projects` repos, but that is an easy update to make following a merge of these changes

I already shaved off 0.02 GB by dropping `parity` (cf. note in code below), and I bet we can get even more things out of here?

## Reviewing notes

In my testing I:

- Generated a scaffold and did some CRUD-ing
- Changed the SQLite DB config to `rails_template_development`; everything worked fine (i.e. Postgres is working)

I did all testing only in a Codespace. We removed all references and links to Gitpod in all content a student will see; so we don't expect anyone to use it (and indeed ~100 students this quarter were a-okay on Codespaces). I don't expect any issues there given the success in Codespaces and functionality of Postgres (which is I think where Gitpod gave us past trouble?)

The Docker image is here:

https://hub.docker.com/repository/docker/firstdraft/appdev-rails-template/tags

Compare the 990MB size with the original (1.3 GB):

https://hub.docker.com/r/jelaniwoods/appdev2023-rails-template/tags

Uncompressed in a codespace (top one is this PR, second is a recent students based on older image, third is a fairly minimal image I was using during Django work):

![image](https://github.com/appdev-projects/rails-7-template/assets/12408296/269acdd2-e5cb-4290-9578-c38e37918eb9)


**Perhaps the image could be a bit smaller, but > 1 GB shaved off for now seems like a good start. We can reduce further if needed. Startup of the codespace is also noticeably faster now 🎉 **
