### PR TITLE
Add alias for rake grade and reset_token

### DIFF
--- a/appdev.Dockerfile
+++ b/appdev.Dockerfile
@@ -204,5 +204,9 @@ __git_complete g __git_main" >> ~/.bash_aliases
 RUN echo "alias be='bundle exec'" >> ~/.bash_aliases
 # RUN sudo cp -r /home/student /home/gitpod && sudo chmod 777 /home/gitpod
 
+# Alias rake grade to grade
+RUN echo "alias grade='rake grade'" >> ~/.bash_aliases
+RUN echo "alias grade:reset_token='rake grade:reset_token'" >> ~/.bash_aliases
+
 # Add bin/rake to path for non-Rails projects
 RUN echo 'export PATH="$PWD/bin:$PATH"' >> ~/.bashrc


### PR DESCRIPTION
Resolves https://github.com/firstdraft/grade_runner/issues/77.

Per the linked `grade_runner` issue, we discussed there adding the CLI `grade` directly to the gem. However, this didn't seem totally straightforward, and, on that ticket we discussed that since we are requiring Codespaces (and Gitpod as a backup), and we have totally removed any "local setup" instructions from the content, then a simple alias in the Dockerfile is acceptable.

In my Codespace testing, I checked the aliases for `rake grade` and `rake grade:reset_token`. I didn't actually try to connect a project, but maybe that's something we should test? I don't see how that could be an issue though, as these are just some simple alias additions.