### PR TITLE
Enable SSL enforcement on Production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,7 +49,7 @@ Rails.application.configure do
   # config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new(STDOUT)


### PR DESCRIPTION
In the past Heroku required paid dynos for auto SSL certs management, which is probably why we had it off. 

Render does not charge for this: https://docs.render.com/tls

Fly.io is also free for the first 10: https://fly.io/docs/about/pricing/#managed-ssl-certificates; and at only $0.10/mo per additional, this is likely still below the $5 "free limit"; in any case, we plan to promote Fly.io as a professional / long-term / paid portfolio option, and primarily stick with Render for deployment.

Not sure we need to do any testing here? The Render docs are pretty clear.