### PR TITLE
Dockerfile updates based on Hotwire Codex requirements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,6 +73,7 @@ end
 
 # AppDev Gems
 # ===========
+gem "foreman"
 gem "appdev_support"
 gem "awesome_print"
 gem "devise"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,6 +153,7 @@ GEM
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake
+    foreman (0.88.1)
     globalid (1.2.1)
       activesupport (>= 6.1)
     grade_runner (0.0.9)
@@ -427,6 +428,7 @@ DEPENDENCIES
   draft_generators
   draft_matchers
   faker
+  foreman
   grade_runner
   htmlbeautifier
   http

--- a/appdev.Dockerfile
+++ b/appdev.Dockerfile
@@ -82,7 +82,7 @@ RUN /bin/bash -l -c "bundle install"
 
 # Install Google Chrome
 RUN sudo apt-get update && sudo apt-get install -y libxss1 && sudo rm -rf /var/lib/atp/lists/*
-RUN wget https://dl.google.com/linux/chrome/deb/pool/main/g/google-chrome-stable/google-chrome-stable_114.0.5735.198-1_amd64.deb && \
+RUN wget https://mirror.cs.uchicago.edu/google-chrome/pool/main/g/google-chrome-stable/google-chrome-stable_114.0.5735.198-1_amd64.deb && \
     sudo apt-get install -y ./google-chrome-stable_114.0.5735.198-1_amd64.deb
 
 # Install Chromedriver (compatable with Google Chrome version)
@@ -98,11 +98,15 @@ RUN BROWSER_MAJOR=$(google-chrome --version | sed 's/Google Chrome \([0-9]*\).*/
     if [ $BROWSER_MAJOR != $DRIVER_MAJOR ]; then echo "VERSION MISMATCH"; exit 1; fi
 
 
-# Install PostgreSQL
-RUN sudo install-packages postgresql-12 postgresql-contrib-12
+# Install PostgreSQL v14
+# https://ethanmick.com/how-to-install-and-setup-postgresql-14-on-ubuntu-20-04/
+RUN sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' \
+    && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add - \
+    && sudo apt-get update \
+    && sudo apt-get -y install postgresql-14
 
 # Setup PostgreSQL server for user student
-ENV PATH="$PATH:/usr/lib/postgresql/12/bin"
+ENV PATH="$PATH:/usr/lib/postgresql/14/bin"
 ENV PGDATA="/workspaces/.pgsql/data"
 RUN sudo mkdir -p $PGDATA
 RUN mkdir -p $PGDATA ~/.pg_ctl/bin ~/.pg_ctl/sockets \
@@ -145,6 +149,7 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
     && sudo npm install -g n \
     && sudo n 18 \
     && hash -r \
+    && sudo chmod 777 /home/student/.cache \
     && sudo rm -rf /var/lib/apt/lists/*
 
 # Install Redis.


### PR DESCRIPTION
While working on the Hotwire Codex book and getting setup in a codesapce, I needed to make various changes to our dockerfile (currently pushed this version as `firstdraft/appdev-rails-7-1-hotwire-codex-template`)

These changes should be tested in our AppDev-1 and 2 projects to see if we can just return to a single image with:

```
docker build --platform linux/amd64 -t firstdraft/appdev-rails-7-1-template -f appdev.Dockerfile .

docker push firstdraft/appdev-rails-7-1-template
```

Updated dockerfile coming from: https://github.com/appdev-projects/piazza-web/blob/main/appdev.Dockerfile